### PR TITLE
Update DefaultTAPErrorWriter.java

### DIFF
--- a/src/tap/error/DefaultTAPErrorWriter.java
+++ b/src/tap/error/DefaultTAPErrorWriter.java
@@ -304,13 +304,13 @@ public class DefaultTAPErrorWriter implements ServiceErrorWriter {
 
 			// Add the list of all causes' message:
 			if (causes.length() > 0)
-				addInfos.put("CAUSES", "\n" + nbCauses + causes.toString());
+				addInfos.put("CAUSES", "\n" + nbCauses + "\n<![CDATA[\n" + causes.toString() + "\n]]>\n"); // added CDATA to wrap free text to make error document parsable
 
 			// Add the stack trace of the original exception ONLY IF NOT A TAP NOR A UWS EXCEPTION (only unexpected error should be detailed to the users):
 			if (!(lastCause instanceof TAPException && lastCause instanceof UWSException)){
 				ByteArrayOutputStream stackTrace = new ByteArrayOutputStream();
 				lastCause.printStackTrace(new PrintStream(stackTrace));
-				addInfos.put("ORIGIN_STACK_TRACE", "\n" + nbStackTraces + "\n" + stackTrace.toString());
+				addInfos.put("ORIGIN_STACK_TRACE", "\n" + nbStackTraces + "\n" + "\n<![CDATA[\n" + stackTrace.toString() + "\n]]>\n"); // added CDATA to wrap free text to make error document parsable
 			}
 		}
 	}


### PR DESCRIPTION
TAP service returns an invalid error document, which is not parsable.

When running the TAP query with a syntax error in 'async' mode, e.g. "SELECT TOP 1000 FROM TAP_SCHEMA.schemas" (missing '*'), The error page created would include two INFO element, namely, 'CAUSES' and 'ORIGIN_STACK_TRACE', as follows:
<INFO  name="CAUSES" value="1">
        -  Encountered "FROM". Was expecting one of: "(" "+" "-" "*" "AVG" "MAX" "MIN" "SUM" "COUNT" "BOX" "CENTROID" "CIRCLE" "POINT" "POLYGON" "REGION" "CONTAINS" "INTERSECTS" "AREA" "COORD1" "COORD2" "COORDSYS" "DISTANCE" "ABS" "CEILING" "DEGREES" "EXP" "FLOOR" "LOG" "LOG10" "MOD" "PI" "POWER" "RADIANS" "RAND" "ROUND" "SQRT" "TRUNCATE" "ACOS" "ASIN" "ATAN" "ATAN2" "COS" "COT" "SIN" "TAN" "\'" <SCIENTIFIC_NUMBER> <UNSIGNED_FLOAT> <UNSIGNED_INTEGER> "\"" <REGULAR_IDENTIFIER_CANDIDATE> <REGULAR_IDENTIFIER_CANDIDATE> "\""
(HINT: "FROM" is a reserved ADQL word. To use it as a column/table/schema name/alias, write it between double quotes.)
</INFO>
<INFO  name="ORIGIN_STACK_TRACE" value="2">
adql.parser.ParseException:  Encountered "FROM". Was expecting one of: "(" "+" "-" "*" "AVG" "MAX" "MIN" "SUM" "COUNT" "BOX" "CENTROID" "CIRCLE" "POINT" "POLYGON" "REGION" "CONTAINS" "INTERSECTS" "AREA" "COORD1" "COORD2" "COORDSYS" "DISTANCE" "ABS" "CEILING" "DEGREES" "EXP" "FLOOR" "LOG" "LOG10" "MOD" "PI" "POWER" "RADIANS" "RAND" "ROUND" "SQRT" "TRUNCATE" "ACOS" "ASIN" "ATAN" "ATAN2" "COS" "COT" "SIN" "TAN" "\'" <SCIENTIFIC_NUMBER> <UNSIGNED_FLOAT> <UNSIGNED_INTEGER> "\"" <REGULAR_IDENTIFIER_CANDIDATE> <REGULAR_IDENTIFIER_CANDIDATE> "\""
(HINT: "FROM" is a reserved ADQL word. To use it as a column/table/schema name/alias, write it between double quotes.)
        at adql.parser.ADQLParser.generateParseException(ADQLParser.java:6320)
        at adql.parser.ADQLParser.jj_consume_token(ADQLParser.java:6180)
        at adql.parser.ADQLParser.SelectItem(ADQLParser.java:1318)
        at adql.parser.ADQLParser.Select(ADQLParser.java:1162)
        at adql.parser.ADQLParser.QueryExpression(ADQLParser.java:1051)
        at adql.parser.ADQLParser.Query(ADQLParser.java:1010)
        at adql.parser.ADQLParser.parseQuery(ADQLParser.java:451)
        at tap.ADQLExecutor.parseADQL(ADQLExecutor.java:571)
        at tap.ADQLExecutor.start(ADQLExecutor.java:366)
        at tap.ADQLExecutor.start(ADQLExecutor.java:226)
        at tap.AsyncThread.jobWork(AsyncThread.java:81)
        at uws.job.JobThread.run(JobThread.java:430)

</INFO>

These two INFO elements contain free text that is not parsable by the xml parser, resulting in an error. You can try this out on TOPCAT.
The error I am getting from the parser is  
 The element type "REGULAR_IDENTIFIER" must be terminated by the matching end-tag "</REGULAR_IDENTIFIER>".

To fix it, CDATA (Character Data that should not be interpreted as XML markup) should be used around all free text:

<![CDATA[
free text with <REGULAR_IDENTIFIER>  or whatever
]]>