### PR TITLE
[ADQL] replace #features-adql-geo with #features-adqlgeo

### DIFF
--- a/src/adql/parser/feature/LanguageFeature.java
+++ b/src/adql/parser/feature/LanguageFeature.java
@@ -16,7 +16,7 @@ package adql.parser.feature;
  * You should have received a copy of the GNU Lesser General Public License
  * along with ADQLLibrary.  If not, see <http://www.gnu.org/licenses/>.
  *
- * Copyright 2019-2022 - UDS/Centre de Données astronomiques de Strasbourg (CDS)
+ * Copyright 2019-2023 - UDS/Centre de Données astronomiques de Strasbourg (CDS)
  */
 
 import java.util.Objects;
@@ -52,7 +52,7 @@ import adql.db.FunctionDef;
  * </i></p>
  *
  * @author Gr&eacute;gory Mantelet (CDS)
- * @version 2.0 (10/2022)
+ * @version 2.0 (03/2023)
  * @since 2.0
  *
  * @see FeatureSet

--- a/test/adql/parser/TestADQLParser.java
+++ b/test/adql/parser/TestADQLParser.java
@@ -912,7 +912,7 @@ public class TestADQLParser {
 			assertEquals(UnresolvedIdentifiersException.class, t.getClass());
 			UnresolvedIdentifiersException allErrors = (UnresolvedIdentifiersException)t;
 			assertEquals(1, allErrors.getNbErrors());
-			assertEquals("Unsupported ADQL feature: \"POINT\" (of type 'ivo://ivoa.net/std/TAPRegExt#features-adql-geo')!", allErrors.getErrors().next().getMessage());
+			assertEquals("Unsupported ADQL feature: \"POINT\" (of type '"+LanguageFeature.TYPE_ADQL_GEO+"')!", allErrors.getErrors().next().getMessage());
 		}
 
 		// now support only POINT:
@@ -961,7 +961,7 @@ public class TestADQLParser {
 				assertTrue(pe instanceof UnresolvedIdentifiersException);
 				UnresolvedIdentifiersException ex = (UnresolvedIdentifiersException)pe;
 				assertEquals(1, ex.getNbErrors());
-				assertEquals("Unsupported ADQL feature: \"INTERSECTS\" (of type 'ivo://ivoa.net/std/TAPRegExt#features-adql-geo')!", ex.getErrors().next().getMessage());
+				assertEquals("Unsupported ADQL feature: \"INTERSECTS\" (of type '"+LanguageFeature.TYPE_ADQL_GEO+"')!", ex.getErrors().next().getMessage());
 			}
 
 			// TODO Test by adding REGION: // Only possible with ADQL-2.0 since in ADQL-2.1, REGION has been removed!
@@ -985,7 +985,7 @@ public class TestADQLParser {
 				assertTrue(pe instanceof UnresolvedIdentifiersException);
 				UnresolvedIdentifiersException ex = (UnresolvedIdentifiersException)pe;
 				assertEquals(1, ex.getNbErrors());
-				assertEquals("Unsupported region type: \"BOX\" (equivalent to the ADQL feature \"BOX\" of type 'ivo://ivoa.net/std/TAPRegExt#features-adql-geo')!", ex.getErrors().next().getMessage());
+				assertEquals("Unsupported region type: \"BOX\" (equivalent to the ADQL feature \"BOX\" of type '"+LanguageFeature.TYPE_ADQL_GEO+"')!", ex.getErrors().next().getMessage());
 			}
 
 			// Test with several geometries while none geometry is allowed:
@@ -1000,9 +1000,9 @@ public class TestADQLParser {
 				UnresolvedIdentifiersException ex = (UnresolvedIdentifiersException)pe;
 				assertEquals(3, ex.getNbErrors());
 				Iterator<ParseException> itErrors = ex.getErrors();
-				assertEquals("Unsupported ADQL feature: \"CONTAINS\" (of type 'ivo://ivoa.net/std/TAPRegExt#features-adql-geo')!", itErrors.next().getMessage());
-				assertEquals("Unsupported ADQL feature: \"POINT\" (of type 'ivo://ivoa.net/std/TAPRegExt#features-adql-geo')!", itErrors.next().getMessage());
-				assertEquals("Unsupported ADQL feature: \"CIRCLE\" (of type 'ivo://ivoa.net/std/TAPRegExt#features-adql-geo')!", itErrors.next().getMessage());
+				assertEquals("Unsupported ADQL feature: \"CONTAINS\" (of type '"+LanguageFeature.TYPE_ADQL_GEO+"')!", itErrors.next().getMessage());
+				assertEquals("Unsupported ADQL feature: \"POINT\" (of type '"+LanguageFeature.TYPE_ADQL_GEO+"')!", itErrors.next().getMessage());
+				assertEquals("Unsupported ADQL feature: \"CIRCLE\" (of type '"+LanguageFeature.TYPE_ADQL_GEO+"')!", itErrors.next().getMessage());
 			}
 		}
 	}


### PR DESCRIPTION
Given the change in the ADQL 2.1 draft at
https://github.com/ivoa-std/ADQL/commit/18a9c19a77c, LanguageFeature.TYPE_ADQL_GEO should read "#features-adqlgeo" instead of "#features-adql-geo".