### PR TITLE
Gradle and Ant build scripts updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,10 @@ Below are summed up the dependencies of each library:
 | Package `cds.utils`    |  X   |     |  X  |
 | Postgres JDBC Driver   |  X   |     |  X  |
 | Package `uws`          |      |  X  |  X  |
-| JSON library            |      |  X  |  X  |
+| JSON library           |      |  X  |  X  |
 | HTTP Servlet API       |      |  X  |  X  |
 | HTTP Multipart Library |      |  X  |  X  |
+| XML Library            |      |  X  |     |
 | Packages `cds.*`       |      |     |  X  |
 | STIL Library           |      |     |  X  |
 

--- a/README.md
+++ b/README.md
@@ -73,10 +73,12 @@ You may also need another library called `hamcrest`. You can find this one on it
 ### ANT scripts
 At the root of the repository, there are 3 ANT scripts. Each is dedicated to one library. They are able to generate JAR for sources, binaries and Javadoc.
 
-4 properties must be set before using one of these scripts:
+6 properties must be set before using one of these scripts:
 * `POSTGRES` *only for ADQL and TAP if you want to keep adql.translator.PgSphereTranslator*: a path toward a JAR or a binary directory containing all `org.postgresql.*` - [https://jdbc.postgresql.org/download.html](JDBC Postgres driver)
 * `SERVLET-API` *only for UWS and TAP*: a path toward a JAR or a binary directory containing all `javax.servlet.*`
+* `XML-API` *only for UWS*: a path toward a JAR or binary directory containing all `javax.xml`
 * `JUNIT-API` *not required if you are not interested by running the JUnit tests*: a path toward one or several JARs or binary directories containing all classes to use JUnit.
+* `HAMCREST` *not required if you are not interested by running the JUnit tests*: a path toward a or binary JAR containing the hamcrest library, required by JUnit.
 * `JNDI-API`  *only for TAP AND only if you are interested by running the JUnit tests*: a path toward one or several JARs or binary directories containing all classes to run a JNDI. Several libraries exist for that ; [Simple-JNDI](https://code.google.com/archive/p/osjava/wikis/SimpleJNDI.wiki) is very simple and is used by the libraries developer to run the related JUnit tests.
 
 *__Note:__ No JNDI library is provided in this Git repository because any JNDI Library may work and there is no reason to impose a specific one. Besides, similarly as the other libraries required to compile the sources, it lets avoiding version incompatibility with the host system (i.e. your machine when you checkout/clone/fork this repository).*

--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,7 @@ repositories {
 dependencies {
     compile fileTree(dir: 'lib', includes: ['stil_3.3-2.jar'])
     compile 'javax.servlet:javax.servlet-api:3.0.1'
+    compile 'javax.xml.bind:jaxb-api:2.3.1'
     compile 'postgresql:postgresql:9.1-901.jdbc4'
     compile 'org.slf4j:slf4j-api:1.7.25'
     compile 'commons-io:commons-io:2.6'
@@ -40,5 +41,5 @@ sourceSets.main.java.srcDirs = ["src"]
 sourceSets.test.java.srcDirs = ["test"]
 
 /* Set the minimum Java version compatibility: */
-sourceCompatibility = '1.7'
-targetCompatibility = '1.7'
+sourceCompatibility = '1.9'
+targetCompatibility = '1.9'

--- a/buildADQL.xml
+++ b/buildADQL.xml
@@ -35,9 +35,13 @@
 		<condition><not><isset property="JUNIT-API"/></not></condition>
 	</fail>
 	
+	<fail message="The property HAMCREST must be set! It provides the path toward a directory or a JAR which contains the hamcrest library, required by JUnit.">
+		<condition><not><isset property="HAMCREST"/></not></condition>
+	</fail>
+
 	<!-- JAVA VERSION COMPATIBILITY -->
-	<property name="ant.build.javac.source" value="1.7"/>
-	<property name="ant.build.javac.target" value="1.7"/>
+	<property name="ant.build.javac.source" value="1.9"/>
+	<property name="ant.build.javac.target" value="1.9"/>
 	
 	<!-- CLASSPATHS -->
 	<path id="adql.classpath">
@@ -47,6 +51,8 @@
 	<path id="junit.class.path">
 		<path refid="adql.classpath" />
 		<pathelement path="${JUNIT-API}" />
+		<pathelement path="${HAMCREST}" />
+		<pathelement path="${TAP-API}" />
 		<pathelement location="bin" />
 	</path>
 	
@@ -144,8 +150,9 @@
 	</target>
 	
 	<target name="compileJavadoc" depends="cleanJavadoc" description="After 'cleanJavadoc', compile the whole Javadoc.">
-		<javadoc encoding="utf-8" charset="utf-8" docencoding="utf-8" access="protected" author="true" classpath="." destdir="${javadocDir}" nodeprecated="false" nodeprecatedlist="false" noindex="false" nonavbar="false" notree="false" source="1.7" splitindex="true" use="true" version="true">
+		<javadoc encoding="utf-8" charset="utf-8" docencoding="utf-8" access="protected" author="true" classpath="." destdir="${javadocDir}" nodeprecated="false" nodeprecatedlist="false" noindex="false" nonavbar="false" notree="false" source="1.9" splitindex="true" use="true" version="true">
 			<packageset dir="${srcDir}" includes="${includesList}" />
+			<classpath refid="adql.classpath" />
 		</javadoc>
 	</target>
 	

--- a/buildTAP.xml
+++ b/buildTAP.xml
@@ -68,14 +68,22 @@
 	<fail message="The property JUNIT-API must be set! It provides the path toward a directory or a JAR which contains all classes needed to use JUnit.">
 		<condition><not><isset property="JUNIT-API"/></not></condition>
 	</fail>
+	
+	<fail message="The property HAMCREST must be set! It provides the path toward a directory or a JAR which contains the hamcrest library, required by JUnit.">
+		<condition><not><isset property="HAMCREST"/></not></condition>
+	</fail>
 
 	<fail message="The property JNDI-API must be set! It provides the path toward a directory or a JAR which contains all classes needed to use Simple-JNDI.">
 		<condition><not><isset property="JNDI-API"/></not></condition>
 	</fail>
+
+	<fail message="The property XML-API must be set! It provides the path toward a directory or a JAR which contains all classes inside javax.xml.">
+		<condition><not><isset property="XML-API"/></not></condition>
+	</fail>
 	
 	<!-- JAVA VERSION COMPATIBILITY -->
-	<property name="ant.build.javac.source" value="1.7"/>
-	<property name="ant.build.javac.target" value="1.7"/>
+	<property name="ant.build.javac.source" value="1.9"/>
+	<property name="ant.build.javac.target" value="1.9"/>
 	
 	<!-- CLASSPATHS -->
 	<path id="tap.classpath">
@@ -86,6 +94,8 @@
 		<pathelement location="${stilJar}" />
 		<pathelement location="${POSTGRES}" />
 		<pathelement location="${SERVLET-API}" />
+		<pathelement location="${XML-API}" />
+
 	</path>
 	
 	<path id="h2.classpath">
@@ -98,6 +108,7 @@
 	<path id="junit.class.path">
 		<pathelement path="${JNDI-API}" />
 		<pathelement path="${JUNIT-API}" />
+		<pathelement path="${HAMCREST}" />
 			
 		<path refid="tap.classpath" />
 		<pathelement location="bin" />
@@ -224,7 +235,7 @@
 	</target>
 	
 	<target name="compileJavadoc" depends="cleanJavadoc" description="After 'cleanJavadoc', compile the whole Javadoc.">
-		<javadoc encoding="utf-8" charset="utf-8" docencoding="utf-8" access="protected" author="true" destdir="${javadocDir}" nodeprecated="false" nodeprecatedlist="false" noindex="false" nonavbar="false" notree="false" source="1.7" splitindex="true" use="true" version="true">
+		<javadoc encoding="utf-8" charset="utf-8" docencoding="utf-8" access="protected" author="true" destdir="${javadocDir}" nodeprecated="false" nodeprecatedlist="false" noindex="false" nonavbar="false" notree="false" source="1.9" splitindex="true" use="true" version="true">
 			<packageset dir="${srcDir}" includes="${includesList}" />
 			<classpath refid="tap.classpath" />
 		</javadoc>

--- a/buildUWS.xml
+++ b/buildUWS.xml
@@ -40,10 +40,22 @@
 	<fail message="The property SERVLET-API must be set! It provides the path toward a directory or a JAR which contains all classes inside javax.servlet.">
 		<condition><not><isset property="SERVLET-API"/></not></condition>
 	</fail>
+
+	<fail message="The property XML-API must be set! It provides the path toward a directory or a JAR which contains all classes inside javax.xml.">
+		<condition><not><isset property="XML-API"/></not></condition>
+	</fail>	
+	
+	<fail message="The property JUNIT-API must be set! It provides the path toward a directory or a JAR which contains all classes needed to use JUnit.">
+		<condition><not><isset property="JUNIT-API"/></not></condition>
+	</fail>
+	
+	<fail message="The property HAMCREST must be set! It provides the path toward a directory or a JAR which contains the hamcrest library, required by JUnit.">
+		<condition><not><isset property="HAMCREST"/></not></condition>
+	</fail>
 	
 	<!-- JAVA VERSION COMPATIBILITY -->
-	<property name="ant.build.javac.source" value="1.7"/>
-	<property name="ant.build.javac.target" value="1.7"/>
+	<property name="ant.build.javac.source" value="1.9"/>
+	<property name="ant.build.javac.target" value="1.9"/>
 
 	<!-- CLASSPATHS -->
 	<path id="uws.classpath">
@@ -52,11 +64,13 @@
 		<pathelement location="${slf4jApiJar}" />
 		<pathelement location="${jsonJar}" />
 		<pathelement location="${SERVLET-API}" />
+		<pathelement location="${XML-API}" />
 	</path>
 	
 	<path id="junit.class.path">
 		<path refid="uws.classpath" />
 		<pathelement path="${JUNIT-API}" />
+		<pathelement path="${HAMCREST}" />
 		<pathelement location="bin" />
 	</path>
 	
@@ -148,7 +162,7 @@
 	</target>
 	
 	<target name="compileJavadoc" depends="cleanJavadoc" description="After 'cleanJavadoc', compile the whole Javadoc.">
-		<javadoc encoding="utf-8" charset="utf-8" docencoding="utf-8" access="protected" author="true" destdir="${javadocDir}" nodeprecated="false" nodeprecatedlist="false" noindex="false" nonavbar="false" notree="false" source="1.7" splitindex="true" use="true" version="true">
+		<javadoc encoding="utf-8" charset="utf-8" docencoding="utf-8" access="protected" author="true" destdir="${javadocDir}" nodeprecated="false" nodeprecatedlist="false" noindex="false" nonavbar="false" notree="false" source="1.9" splitindex="true" use="true" version="true">
 			<packageset dir="${srcDir}" includes="${includesList}" />
 			<classpath refid="uws.classpath" />
 		</javadoc>


### PR DESCRIPTION
Attempting to build using later versions of Apache Ant (tested 1.10.14) and Gradle (tested 4.4.1) are currently incompatible with the current build scripts due to the following reasons:

- Dropped Support for Java 7
- Java extensions no longer being included with JDK (thus now requiring the dependency of JAXB)

In addition there are issues with JUnit tests failed to compile on Ant. In order to build the `hamcrest` jar had to be declared separately which JUnit relies on. `adql` tests failed to compile due to the dependency on the TAP classes. 

This PR modifies the Gradle and Ant scripts such that:
- Minimum Java version increased to 9 (8 is soon to be no longer supported).
- JAXB xml library, previously included with JDK, is now a dependency
- `HAMCREST`, `XML-API` added as required properties for the Ant Scripts. `TAP-API` is also a used property when compiling the JUnit scripts however not required to maintain `adql`'s independence.